### PR TITLE
Refactor mget

### DIFF
--- a/cachegeneric.go
+++ b/cachegeneric.go
@@ -1,0 +1,153 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/daoshenzzg/jetcache-go/logger"
+	"github.com/daoshenzzg/jetcache-go/util"
+)
+
+// T wrap Cache to support golang's generics
+type T[K comparable, V any] struct {
+	Cache
+}
+
+// NewT new a T
+func NewT[K comparable, V any](cache Cache) *T[K, V] {
+	return &T[K, V]{cache}
+}
+
+// MGet efficiently fetches multiple values associated with a specific key prefix and a list of IDs in a single call.
+// It prioritizes retrieving data from the cache and falls back to a user-provided function (`fn`) if values are missing.
+// Asynchronous refresh is not supported.
+func (w *T[K, V]) MGet(ctx context.Context, key string, ids []K, fn func(context.Context, []K) (map[K]V, error)) map[K]V {
+	c := w.Cache.(*jetCache)
+	values, missIds := w.mGetCache(ctx, key, ids)
+
+	if len(missIds) > 0 && fn != nil {
+		c.statsHandler.IncrQuery()
+
+		fnValues, err := fn(ctx, missIds)
+		if err != nil {
+			c.statsHandler.IncrQueryFail(err)
+			logger.Error("MGet#fn(%s) error(%v)", util.JoinAny(",", ids), err)
+		} else {
+			placeholderValues := make(map[string]any, len(ids))
+			cacheValues := make(map[string]any, len(ids))
+			for rk, rv := range fnValues {
+				values[rk] = rv
+				cacheKey := util.JoinAny(":", key, rk)
+				if b, err := c.Marshal(rv); err != nil {
+					placeholderValues[cacheKey] = notFoundPlaceholder
+					logger.Error("MGet#w.Marshal(%v) error(%v)", rv, err)
+				} else {
+					cacheValues[cacheKey] = b
+				}
+			}
+
+			for _, missId := range missIds {
+				if _, ok := values[missId]; !ok {
+					cacheKey := util.JoinAny(":", key, missId)
+					placeholderValues[cacheKey] = notFoundPlaceholder
+				}
+			}
+
+			if c.local != nil {
+				if len(placeholderValues) > 0 {
+					for key, value := range placeholderValues {
+						c.local.Set(key, value.([]byte))
+					}
+				}
+				if len(cacheValues) > 0 {
+					for key, value := range cacheValues {
+						c.local.Set(key, value.([]byte))
+					}
+				}
+			}
+
+			if c.remote != nil {
+				if len(placeholderValues) > 0 {
+					if err = c.remote.MSet(ctx, placeholderValues, c.notFoundExpiry); err != nil {
+						logger.Error("MGet#MSet error(%v)", err)
+					}
+				}
+				if len(cacheValues) > 0 {
+					if err = c.remote.MSet(ctx, cacheValues, c.remoteExpiry); err != nil {
+						logger.Error("MGet#MSet error(%v)", err)
+					}
+				}
+			}
+		}
+	}
+
+	return values
+}
+
+func (w *T[K, V]) mGetCache(ctx context.Context, key string, ids []K) (v map[K]V, missIds []K) {
+	c := w.Cache.(*jetCache)
+	v = make(map[K]V, len(ids))
+	miss := make(map[string]K, len(ids))
+
+	for _, id := range ids {
+		cacheKey := util.JoinAny(":", key, id)
+		if c.local != nil {
+			if b, ok := c.local.Get(cacheKey); ok {
+				c.statsHandler.IncrHit()
+				c.statsHandler.IncrLocalHit()
+				if bytes.Compare(b, notFoundPlaceholder) == 0 {
+					continue
+				}
+				var varT V
+				if err := c.Unmarshal(b, &varT); err != nil {
+					logger.Error("mGetCache#c.Unmarshal(%s) error(%v)", cacheKey, err)
+				} else {
+					v[id] = varT
+				}
+			} else {
+				miss[cacheKey] = id
+				c.statsHandler.IncrLocalMiss()
+			}
+		} else {
+			miss[cacheKey] = id
+		}
+	}
+
+	if len(miss) > 0 && c.remote != nil {
+		missKeys := make([]string, 0, len(miss))
+		for k := range miss {
+			missKeys = append(missKeys, k)
+		}
+		if values, err := c.remote.MGet(ctx, missKeys...); err == nil {
+			for mk, mv := range miss {
+				if val, ok := values[mk]; ok {
+					c.statsHandler.IncrHit()
+					c.statsHandler.IncrRemoteHit()
+					delete(miss, mk)
+					b := util.Bytes(val.(string))
+					if bytes.Compare(b, notFoundPlaceholder) == 0 {
+						continue
+					}
+					var varT V
+					if err = c.Unmarshal(b, &varT); err != nil {
+						logger.Error("mGetCache#c.Unmarshal(%s) error(%v)", mk, err)
+					} else {
+						v[mv] = varT
+						if c.local != nil {
+							c.local.Set(mk, b)
+						}
+					}
+				} else {
+					c.statsHandler.IncrRemoteMiss()
+				}
+			}
+		}
+	}
+
+	for _, mv := range miss {
+		missIds = append(missIds, mv)
+		c.statsHandler.IncrMiss()
+	}
+
+	return
+}

--- a/cacheopt.go
+++ b/cacheopt.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"time"
 
-	"github.com/daoshenzzg/jetcache-go/encoding/sonic"
+	"github.com/daoshenzzg/jetcache-go/encoding/msgpack"
 	"github.com/daoshenzzg/jetcache-go/local"
 	"github.com/daoshenzzg/jetcache-go/remote"
 	"github.com/daoshenzzg/jetcache-go/stats"
@@ -14,7 +14,7 @@ const (
 	defaultRefreshConcurrency = 4
 	defaultRemoteExpiry       = time.Hour
 	defaultNotFoundExpiry     = time.Minute
-	defaultCodec              = sonic.Name
+	defaultCodec              = msgpack.Name
 	maxOffset                 = 10 * time.Second
 )
 
@@ -24,7 +24,7 @@ type (
 		name                       string        // Cache name, used for log identification and metric reporting
 		remote                     remote.Remote // Remote is distributed cache, such as Redis.
 		local                      local.Local   // Local is memory cache, such as FreeCache.
-		codec                      string        // Value encoding and decoding method. Default is "sonic.Name". You can also customize it.
+		codec                      string        // Value encoding and decoding method. Default is "msgpack.Name". You can also customize it.
 		errNotFound                error         // Error to return for cache miss. Used to prevent cache penetration.
 		remoteExpiry               time.Duration // Remote cache ttl, Default is 1 hour.
 		notFoundExpiry             time.Duration // Duration for placeholder cache when there is a cache miss. Default is 1 minute.

--- a/example_cache_test.go
+++ b/example_cache_test.go
@@ -47,7 +47,7 @@ func Example_basicUsage() {
 		},
 	})
 
-	mycache := cache.New[string, any](cache.WithName("any"),
+	mycache := cache.New(cache.WithName("any"),
 		cache.WithRemote(remote.NewGoRedisV8Adaptor(ring)),
 		cache.WithLocal(local.NewFreeCache(256*local.MB, time.Minute)),
 		cache.WithErrNotFound(errRecordNotFound))
@@ -75,7 +75,7 @@ func Example_advancedUsage() {
 		},
 	})
 
-	mycache := cache.New[string, any](cache.WithName("any"),
+	mycache := cache.New(cache.WithName("any"),
 		cache.WithRemote(remote.NewGoRedisV8Adaptor(ring)),
 		cache.WithLocal(local.NewFreeCache(256*local.MB, time.Minute)),
 		cache.WithErrNotFound(errRecordNotFound),
@@ -102,18 +102,19 @@ func Example_mGetUsage() {
 		},
 	})
 
-	mycache := cache.New[int, *object](cache.WithName("any"),
+	mycache := cache.New(cache.WithName("any"),
 		cache.WithRemote(remote.NewGoRedisV8Adaptor(ring)),
 		cache.WithLocal(local.NewFreeCache(256*local.MB, time.Minute)),
 		cache.WithErrNotFound(errRecordNotFound),
 		cache.WithRemoteExpiry(time.Minute),
 	)
+	cacheT := cache.NewT[int, *object](mycache)
 
 	ctx := context.TODO()
 	key := "mget"
 	ids := []int{1, 2, 3}
 
-	ret := mycache.MGet(ctx, key, ids, func(ctx context.Context, ids []int) (map[int]*object, error) {
+	ret := cacheT.MGet(ctx, key, ids, func(ctx context.Context, ids []int) (map[int]*object, error) {
 		return mockDBMGetObject(ids)
 	})
 
@@ -124,5 +125,5 @@ func Example_mGetUsage() {
 	fmt.Println(b.String())
 	//Output: &{mystring 1}&{mystring 2}<nil>
 
-	mycache.Close()
+	cacheT.Close()
 }


### PR DESCRIPTION
Motivation:

To ensure a good user experience by supporting `MGet` through generics, while also considering full backward compatibility, the `Decorator Pattern` is used to implement generic constraints.

